### PR TITLE
fixed convertLink function in songform

### DIFF
--- a/components/forms/SongForm.js
+++ b/components/forms/SongForm.js
@@ -38,9 +38,16 @@ export default function SongForm({ songObj }) {
 
   // FUNCTION TO CONVERT THE YOUTUBE LINK TO A YOUTUBE EMBED LINK
   const convertLink = (payload) => {
-    const [, videoID] = payload.split('watch?v=');
-    const embedLink = `https://www.youtube.com/embed/${videoID}`;
-    return embedLink;
+    if (payload.includes('watch?v=')) {
+      const [, videoID] = payload.split('watch?v=');
+      const embedLink = `https://www.youtube.com/embed/${videoID}`;
+      return embedLink;
+    } if (payload.includes('youtu.be')) {
+      const [, videoID] = payload.split('youtu.be/');
+      const embedLink = `https://www.youtube.com/embed/${videoID}`;
+      return embedLink;
+    }
+    return payload;
   };
 
   // EVENT HANDLERS


### PR DESCRIPTION
- added else statements to convertLink
- for if 'watch?v=' link,
- for if 'youtu.be' link,
- and for if 'embed' link,
- it will always convert the link to the proper 'embed' link or leave an embed link alone